### PR TITLE
Bug fix and v0.2.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+
+test.js

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Slack Channel Metadata Scraper
 
-##### Latest change: v0.1.9: worked out the issues with capturing threads / threaded comments. SCMS now correctly captures threads, thread comments, and thread replies. 
+##### Latest change: v0.2.0: fixed an issue where if no messages are found for the given timeframe the tool would crash. will now return "No messages to scan" instead of crashing. the count parameter has been moved to the last position in the function - if no count is passed then the default and Slack maximum of 1000 messages will be called for that query
 
 ### This is a tool that captures Slack channel metadata of all users / bot users in a selected timeframe
 
@@ -17,14 +17,13 @@
     - you must also allow the permissions scope "channels.history"
 
 #### Optional
-- `[count]`: number of messages to return in the query
-    - default: 100 messages
-    - maximum: 1000 messages
-
 - `[start]`: beginning timestamp to query message history
     - use most recent metaData.latest for this parameter during daily queries
 
 - `[end]`: ending timestamp to query message history - default to current time
+
+- `[count]`: number of messages to return in the query
+    - default / maximum: 1000 messages
 
 ### Note: if no start / end are passed then the entire message history (up to 1000 messages) will be scanned for metadata
 
@@ -38,6 +37,7 @@
 ### metaData object returned
 
 #### Note: the `timestamp` property is the Slack ts (timestamp) value of the most recent message in the current query
+- all timestamps are non-inclusive meaning if you pass a starting timestamp you will get metadata for all messages _after_ the message that corresponds to that timestamp
 
 #### This timestamp can be used for daily scans as a starting time for the next query (to prevent overlap of data)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slackmetascraper",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Scrapes a Slack channel and returns a metaData object. This object is labelled by the timestamp of the last message scraped during that query. The metadata object contains an array of userMetadata objects which store all surface and nested metadata per user (including bots - identified as such). Metadata is all quantitative data available from a channel. See the readme for details on the output",
   "main": "channelScraper.js",
   "scripts": {


### PR DESCRIPTION
v0.2.0: fixed an issue where if no messages are found for the given timeframe the tool would crash. will now return "No messages to scan" instead of crashing. the count parameter has been moved to the last position in the function - if no count is passed then the default and Slack maximum of 1000 messages will be called for that query